### PR TITLE
Update modules/ecs-service/main.tf and outputs.tf to add data call to aws_partition

### DIFF
--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -12,3 +12,9 @@ resource "random_id" "mock_ecs_service" {
 
   byte_length = 8
 }
+
+# Use this data source to lookup information about the current AWS partition in which Terraform is working.
+# This will return the identifier of the current partition (e.g., aws in AWS Commercial, aws-us-gov in AWS GovCloud,
+# aws-cn in AWS China).
+# https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+data "aws_partition" "current" {}

--- a/modules/ecs-service/outputs.tf
+++ b/modules/ecs-service/outputs.tf
@@ -3,5 +3,5 @@ output "ecs_service_id" {
 }
 
 output "ecs_service_arn" {
-  value = "arn:aws:ecs:${var.aws_region}:123456789012:service/${var.service_name}"
+  value = "arn:${data.aws_partition.current.partition}:ecs:${var.aws_region}:123456789012:service/${var.service_name}"
 }


### PR DESCRIPTION
Fixes #1 

Updated modules/ecs-service/main.tf:

Added:
# Use this data source to lookup information about the current AWS partition in which Terraform is working.
# This will return the identifier of the current partition (e.g., aws in AWS Commercial, aws-us-gov in AWS GovCloud,
# aws-cn in AWS China).
# https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
data "aws_partition" "current" {}

Updated modules/ecs-service/outputs.tf:

Updated:
output "ecs_service_arn" {
  value = "arn:${data.aws_partition.current.partition}:ecs:${var.aws_region}:123456789012:service/${var.service_name}"
}
